### PR TITLE
Update README.md icon-url Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ command-aliases:
 layer-name: Marker
 
 # Define the link to the marker-icon-image
-icon-url: https://cdn.upload.systems/uploads/1zRKxN3t.png
+icon-url: https://github.com/SentixDev/squaremarker/raw/master/resources/default_icon.png
 
 # Define the icon size
 icon-size: 16


### PR DESCRIPTION
Update icon-url to GitHub link as suggested by jpenilla in  "Squremarker doesn't work on 1.19.3 #14"

Plugin errors and server shuts down with current icon link, updating as suggested fixes the issue